### PR TITLE
fix(后端): 只为项目包的 @RestController 添加 /api 前缀

### DIFF
--- a/src/main/java/com/github/listen_to_me/common/config/ApiPrefixConfig.java
+++ b/src/main/java/com/github/listen_to_me/common/config/ApiPrefixConfig.java
@@ -5,11 +5,14 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import cn.hutool.core.util.ClassUtil;
+
 @Configuration
 public class ApiPrefixConfig implements WebMvcConfigurer {
     @Override
     public void configurePathMatch(PathMatchConfigurer configurer) {
         configurer.addPathPrefix("/api",
-                c -> c.isAnnotationPresent(RestController.class));
+                c -> c.isAnnotationPresent(RestController.class)
+                        && ClassUtil.getPackage(c).startsWith("com.github.listen_to_me.controller"));
     }
 }


### PR DESCRIPTION
拦截全部 `RestController` 注解会导致接口文档等其他包接口 404