### PR TITLE
refactor(后端): 集成 Redis 缓存用户权限列表以优化鉴权性能 

### DIFF
--- a/src/main/java/com/github/listen_to_me/common/enumeration/RedisKey.java
+++ b/src/main/java/com/github/listen_to_me/common/enumeration/RedisKey.java
@@ -5,7 +5,8 @@ import java.util.concurrent.TimeUnit;
 
 @Getter
 public enum RedisKey {
-    CAPTCHA("captcha:codes:", 2L, TimeUnit.MINUTES);
+    CAPTCHA("captcha:codes:", 2L, TimeUnit.MINUTES),
+    USER_PERMS("user:perms:", 12L, TimeUnit.HOURS);
 
     private final String prefix;
     private final Long expire;

--- a/src/main/java/com/github/listen_to_me/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/listen_to_me/common/filter/JwtAuthenticationFilter.java
@@ -9,7 +9,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.github.listen_to_me.common.enumeration.RedisKey;
 import com.github.listen_to_me.common.util.JwtUtils;
+import com.github.listen_to_me.common.util.RedisUtils;
 import com.github.listen_to_me.mapper.SysUserMapper;
 
 import io.jsonwebtoken.Claims;
@@ -43,8 +45,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Claims claims = JwtUtils.parseToken(token);
             Long userId = Long.parseLong(claims.getSubject());
 
-            // HACK: 后续添加 Redis 后，在登录时将权限存到 Redis，而不是每次请求都调用一次
-            List<String> permCodeList = sysUserMapper.selectPermCodeListById(userId);
+            List<String> permCodeList = RedisUtils.get(RedisKey.USER_PERMS, userId.toString());
+
+            if (permCodeList == null) {
+                permCodeList = sysUserMapper.selectPermCodeListById(userId);
+                RedisUtils.set(RedisKey.USER_PERMS, userId.toString(), permCodeList);
+                log.debug("权限缓存未命中 - 用户ID: {}", userId);
+            }
+
             log.debug("识别用户 - ID: {}, 权限列表: {}", userId, permCodeList);
             List<SimpleGrantedAuthority> authorities = permCodeList.stream()
                     .map(SimpleGrantedAuthority::new)

--- a/src/main/java/com/github/listen_to_me/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/github/listen_to_me/service/impl/UserDetailsServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.github.listen_to_me.common.enumeration.RedisKey;
+import com.github.listen_to_me.common.util.RedisUtils;
 import com.github.listen_to_me.domain.SysUserAdapter;
 import com.github.listen_to_me.domain.entity.SysUser;
 import com.github.listen_to_me.mapper.SysUserMapper;
@@ -39,6 +41,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         }
 
         List<String> permCodeList = sysUserMapper.selectPermCodeListById(user.getId());
+        RedisUtils.set(RedisKey.USER_PERMS, user.getId().toString(), permCodeList);
+
         log.debug("认证信息就绪 - 账号: {}, 权限: {}", username, permCodeList);
         return new SysUserAdapter(user, permCodeList);
     }


### PR DESCRIPTION
依赖 #20，主要变动：

- 在 `RedisKey` 枚举中新增 `USER_PERMS` 配置
- `JwtAuthenticationFilter` 鉴权时优先从 Redis 读取权限
- `UserDetailsServiceImpl` 登录加载阶段同步更新 Redis 权限缓存