### PR TITLE
chore(后端): 优化日志输出格式

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,7 +26,7 @@ logging:
     root: warn
     com.github.listen_to_me: debug
   pattern:
-    console: "-----------------%n%d{HH:mm:ss} | %highlight(%-4level) | %-15.15thread | %logger.%M |%n%msg%n-----------------%n"
+    console: "%d{HH:mm:ss} | %highlight(%-5level) | %-15.15thread | %logger.%M |%n%msg%n---------------------------------%n"
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
之前：

```shell
-----------------
16:05:59 | INFO | nio-8080-exec-1 | com.github.listen_to_me.common.util.JwtUtils.generateToken |
生成令牌 - 用户ID: 1, 用户名: admin
-----------------
-----------------
16:05:59 | INFO | nio-8080-exec-1 | com.github.listen_to_me.common.util.MinioUtils.getPresignedUrl |
生成临时链接 - 完整路径: https://avatar.com/admin.jpg
-----------------
-----------------
16:05:59 | INFO | nio-8080-exec-1 | com.github.listen_to_me.service.impl.AuthServiceImpl.refreshToken |
刷新令牌 - 用户: admin
-----------------
```

现在：

```shell
---------------------------------
16:06:29 | INFO  | nio-8080-exec-1 | com.github.listen_to_me.common.util.JwtUtils.generateToken |
生成令牌 - 用户ID: 1, 用户名: admin
---------------------------------
16:06:29 | INFO  | nio-8080-exec-1 | com.github.listen_to_me.common.util.MinioUtils.getPresignedUrl |
生成临时链接 - 完整路径: https://avatar.com/admin.jpg
---------------------------------
16:06:29 | INFO  | nio-8080-exec-1 | com.github.listen_to_me.service.impl.AuthServiceImpl.refreshToken |
刷新令牌 - 用户: admin
---------------------------------
```