### PR TITLE
AI 功能实现（转写、摘要、排期）

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,18 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dashscope-sdk-java</artifactId>
+            <version>2.22.14</version>
+            <exclusions>
+                <!-- 排除 dashscope 内嵌的 slf4j-simple 实现，以避免与 Spring Boot 的 Logback 冲突 -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <version>8.5.17</version>

--- a/src/main/java/com/github/listen_to_me/common/config/AiTaskMqConfig.java
+++ b/src/main/java/com/github/listen_to_me/common/config/AiTaskMqConfig.java
@@ -1,0 +1,33 @@
+package com.github.listen_to_me.common.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiTaskMqConfig {
+
+    public static final String EXCHANGE_NAME = "ai.task.exchange";
+    public static final String TRANSCRIPTION_QUEUE = "ai.transcription.queue";
+    public static final String TRANSCRIPTION_ROUTING_KEY = "ai.transcription";
+
+    @Bean
+    public DirectExchange aiTaskExchange() {
+        return new DirectExchange(EXCHANGE_NAME, true, false);
+    }
+
+    @Bean
+    public Queue transcriptionQueue() {
+        return new Queue(TRANSCRIPTION_QUEUE, true);
+    }
+
+    @Bean
+    public Binding transcriptionBinding() {
+        return BindingBuilder.bind(transcriptionQueue())
+                .to(aiTaskExchange())
+                .with(TRANSCRIPTION_ROUTING_KEY);
+    }
+}

--- a/src/main/java/com/github/listen_to_me/common/config/AiTaskMqConfig.java
+++ b/src/main/java/com/github/listen_to_me/common/config/AiTaskMqConfig.java
@@ -13,6 +13,8 @@ public class AiTaskMqConfig {
     public static final String EXCHANGE_NAME = "ai.task.exchange";
     public static final String TRANSCRIPTION_QUEUE = "ai.transcription.queue";
     public static final String TRANSCRIPTION_ROUTING_KEY = "ai.transcription";
+    public static final String SUMMARIZATION_QUEUE = "ai.summarization.queue";
+    public static final String SUMMARIZATION_ROUTING_KEY = "ai.summarization";
 
     @Bean
     public DirectExchange aiTaskExchange() {
@@ -29,5 +31,17 @@ public class AiTaskMqConfig {
         return BindingBuilder.bind(transcriptionQueue())
                 .to(aiTaskExchange())
                 .with(TRANSCRIPTION_ROUTING_KEY);
+    }
+
+    @Bean
+    public Queue summarizationQueue() {
+        return new Queue(SUMMARIZATION_QUEUE, true);
+    }
+
+    @Bean
+    public Binding summarizationBinding() {
+        return BindingBuilder.bind(summarizationQueue())
+                .to(aiTaskExchange())
+                .with(SUMMARIZATION_ROUTING_KEY);
     }
 }

--- a/src/main/java/com/github/listen_to_me/common/config/DashScopeConfig.java
+++ b/src/main/java/com/github/listen_to_me/common/config/DashScopeConfig.java
@@ -1,0 +1,17 @@
+package com.github.listen_to_me.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "aliyun.dashscope")
+public class DashScopeConfig {
+    private String apiKey;
+    private String transcriptionModel;
+    private String summarizationModel;
+    private String translationModel;
+    private String slotModel;
+}

--- a/src/main/java/com/github/listen_to_me/common/consumer/SummarizationConsumer.java
+++ b/src/main/java/com/github/listen_to_me/common/consumer/SummarizationConsumer.java
@@ -1,0 +1,78 @@
+package com.github.listen_to_me.common.consumer;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.github.listen_to_me.common.config.AiTaskMqConfig;
+import com.github.listen_to_me.common.util.MinioUtils;
+import com.github.listen_to_me.domain.entity.AiTask;
+import com.github.listen_to_me.domain.entity.AudioInfo;
+import com.github.listen_to_me.mapper.AiTaskMapper;
+import com.github.listen_to_me.mapper.AudioInfoMapper;
+import com.github.listen_to_me.service.AiService;
+
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class SummarizationConsumer {
+
+    private final AiTaskMapper aiTaskMapper;
+    private final AudioInfoMapper audioInfoMapper;
+    private final AiService aiService;
+
+    @RabbitListener(queues = AiTaskMqConfig.SUMMARIZATION_QUEUE)
+    public void handleSummarizationTask(String jsonMsg) {
+        JSONObject taskData = JSONUtil.parseObj(jsonMsg);
+        String taskId = taskData.getStr("taskId");
+        Long audioId = taskData.getLong("audioId");
+
+        log.debug("收到摘要任务 - taskId: {}, audioId: {}", taskId, audioId);
+
+        AiTask task = aiTaskMapper.selectOne(Wrappers.<AiTask>lambdaQuery().eq(AiTask::getTaskId, taskId));
+        if (task == null) {
+            log.error("任务不存在 - taskId: {}", taskId);
+            return;
+        }
+
+        task.setStatus("PROCESSING");
+        aiTaskMapper.updateById(task);
+
+        try {
+            AudioInfo audio = audioInfoMapper.selectById(audioId);
+            if (audio == null) {
+                throw new RuntimeException("音频不存在");
+            }
+
+            // 生成 MinIO 公网临时 URL
+            String fileUrl = MinioUtils.getPresignedUrl(audio.getRawPath());
+
+            // 调用 AI 生成英文摘要
+            String englishSummary = aiService.generateSummary(fileUrl);
+
+            // 翻译为中文
+            String chineseSummary = aiService.translateSummary(englishSummary);
+
+            // 构建结果 JSON
+            JSONObject result = JSONUtil.createObj()
+                    .set("summary", chineseSummary)
+                    .set("original", englishSummary);
+
+            task.setStatus("SUCCESS");
+            task.setResult(result.toString());
+            aiTaskMapper.updateById(task);
+
+            log.debug("摘要任务成功 - taskId: {}", taskId);
+        } catch (Exception e) {
+            log.error("摘要任务失败 - taskId: {}", taskId, e);
+            task.setStatus("FAILED");
+            task.setFailReason(e.getMessage());
+            aiTaskMapper.updateById(task);
+        }
+    }
+}

--- a/src/main/java/com/github/listen_to_me/common/consumer/TranscriptionConsumer.java
+++ b/src/main/java/com/github/listen_to_me/common/consumer/TranscriptionConsumer.java
@@ -1,0 +1,70 @@
+package com.github.listen_to_me.common.consumer;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.github.listen_to_me.common.config.AiTaskMqConfig;
+import com.github.listen_to_me.common.util.MinioUtils;
+import com.github.listen_to_me.domain.entity.AiTask;
+import com.github.listen_to_me.domain.entity.AudioInfo;
+import com.github.listen_to_me.mapper.AiTaskMapper;
+import com.github.listen_to_me.mapper.AudioInfoMapper;
+import com.github.listen_to_me.service.AiService;
+
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class TranscriptionConsumer {
+
+    private final AiTaskMapper aiTaskMapper;
+    private final AudioInfoMapper audioInfoMapper;
+    private final AiService aiService;
+
+    @RabbitListener(queues = AiTaskMqConfig.TRANSCRIPTION_QUEUE)
+    public void handleTranscriptionTask(String jsonMsg) {
+        JSONObject taskData = JSONUtil.parseObj(jsonMsg);
+        String taskId = taskData.getStr("taskId");
+        Long audioId = taskData.getLong("audioId");
+
+        log.debug("收到转写任务 - taskId: {}, audioId: {}", taskId, audioId);
+
+        AiTask task = aiTaskMapper.selectOne(Wrappers.<AiTask>lambdaQuery().eq(AiTask::getTaskId, taskId));
+        if (task == null) {
+            log.error("任务不存在 - taskId: {}", taskId);
+            return;
+        }
+
+        task.setStatus("PROCESSING");
+        aiTaskMapper.updateById(task);
+
+        try {
+            AudioInfo audio = audioInfoMapper.selectById(audioId);
+            if (audio == null) {
+                throw new RuntimeException("音频不存在");
+            }
+
+            // 生成 MinIO 公网临时 URL
+            String fileUrl = MinioUtils.getPresignedUrl(audio.getRawPath());
+
+            // 调用 AI 转写
+            String result = aiService.transcribe(fileUrl);
+
+            task.setStatus("SUCCESS");
+            task.setResult(result);
+            aiTaskMapper.updateById(task);
+
+            log.debug("转写任务成功 - taskId: {}", taskId);
+        } catch (Exception e) {
+            log.error("转写任务失败 - taskId: {}", taskId, e);
+            task.setStatus("FAILED");
+            task.setFailReason(e.getMessage());
+            aiTaskMapper.updateById(task);
+        }
+    }
+}

--- a/src/main/java/com/github/listen_to_me/common/producer/AiTaskProducer.java
+++ b/src/main/java/com/github/listen_to_me/common/producer/AiTaskProducer.java
@@ -1,0 +1,30 @@
+package com.github.listen_to_me.common.producer;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import com.github.listen_to_me.common.config.AiTaskMqConfig;
+
+import cn.hutool.json.JSONUtil;
+import jakarta.annotation.Resource;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class AiTaskProducer {
+
+    @Resource
+    private RabbitTemplate rabbitTemplate;
+
+    public void sendTranscriptionTask(String taskId, Long audioId) {
+        String json = JSONUtil.createObj()
+                .set("taskId", taskId)
+                .set("audioId", audioId)
+                .toString();
+        rabbitTemplate.convertAndSend(
+                AiTaskMqConfig.EXCHANGE_NAME,
+                AiTaskMqConfig.TRANSCRIPTION_ROUTING_KEY,
+                json);
+        log.debug("发送转写任务 - taskId: {}, audioId: {}", taskId, audioId);
+    }
+}

--- a/src/main/java/com/github/listen_to_me/common/producer/AiTaskProducer.java
+++ b/src/main/java/com/github/listen_to_me/common/producer/AiTaskProducer.java
@@ -27,4 +27,16 @@ public class AiTaskProducer {
                 json);
         log.debug("发送转写任务 - taskId: {}, audioId: {}", taskId, audioId);
     }
+
+    public void sendSummarizationTask(String taskId, Long audioId) {
+        String json = JSONUtil.createObj()
+                .set("taskId", taskId)
+                .set("audioId", audioId)
+                .toString();
+        rabbitTemplate.convertAndSend(
+                AiTaskMqConfig.EXCHANGE_NAME,
+                AiTaskMqConfig.SUMMARIZATION_ROUTING_KEY,
+                json);
+        log.debug("发送摘要任务 - taskId: {}, audioId: {}", taskId, audioId);
+    }
 }

--- a/src/main/java/com/github/listen_to_me/controller/common/AiController.java
+++ b/src/main/java/com/github/listen_to_me/controller/common/AiController.java
@@ -1,8 +1,16 @@
 package com.github.listen_to_me.controller.common;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.listen_to_me.common.Result;
+import com.github.listen_to_me.domain.vo.AiTaskVO;
+import com.github.listen_to_me.service.IAiTaskService;
+
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,4 +21,14 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/common/ai")
 @RestController("commonAiController")
 public class AiController {
+
+    private final IAiTaskService aiTaskService;
+
+    @GetMapping("/task/{taskId}")
+    @Operation(summary = "查询 AI 任务状态")
+    public Result<AiTaskVO> getAiTask(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable String taskId) {
+        return Result.success(aiTaskService.getTaskById(userId, taskId));
+    }
 }

--- a/src/main/java/com/github/listen_to_me/controller/common/AiController.java
+++ b/src/main/java/com/github/listen_to_me/controller/common/AiController.java
@@ -1,0 +1,16 @@
+package com.github.listen_to_me.controller.common;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Tag(name = "AI任务")
+@RequiredArgsConstructor
+@RequestMapping("/common/ai")
+@RestController("commonAiController")
+public class AiController {
+}

--- a/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
+++ b/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
@@ -3,6 +3,7 @@ package com.github.listen_to_me.controller.creator;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +32,13 @@ public class AiController {
             @PathVariable Long audioId) {
         AiTaskVO vo = aiTaskService.createTranscriptionTask(userId, audioId);
         return Result.success(vo);
+    }
+
+    @PutMapping("/transcript/{taskId}/confirm")
+    @Operation(summary = "确认转写结果")
+    public Result<Void> confirmTranscript(@AuthenticationPrincipal Long userId,
+            @PathVariable String taskId) {
+        aiTaskService.confirmTranscript(userId, taskId);
+        return Result.success();
     }
 }

--- a/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
+++ b/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
@@ -1,8 +1,16 @@
 package com.github.listen_to_me.controller.creator;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.listen_to_me.common.Result;
+import com.github.listen_to_me.domain.vo.AiTaskVO;
+import com.github.listen_to_me.service.IAiTaskService;
+
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,4 +21,15 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/creator/ai")
 @RestController("creatorAiController")
 public class AiController {
+
+    private final IAiTaskService aiTaskService;
+
+    @PostMapping("/transcript/{audioId}")
+    @Operation(summary = "申请 AI 转写")
+    public Result<AiTaskVO> saveAiTranscript(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long audioId) {
+        AiTaskVO vo = aiTaskService.createTranscriptionTask(userId, audioId);
+        return Result.success(vo);
+    }
 }

--- a/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
+++ b/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
@@ -55,4 +55,11 @@ public class AiController {
             @RequestBody SlotsGenerateDTO dto) {
         return Result.success(aiService.generateSlots(userId, dto.getDescription()));
     }
+
+    @PostMapping("/note/{audioId}")
+    @Operation(summary = "申请 AI 摘要")
+    public Result<AiTaskVO> saveAiNote(@AuthenticationPrincipal Long userId,
+            @PathVariable Long audioId) {
+        return Result.success(aiTaskService.createSummarizationTask(userId, audioId));
+    }
 }

--- a/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
+++ b/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
@@ -1,0 +1,16 @@
+package com.github.listen_to_me.controller.creator;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Tag(name = "AI增强")
+@RequiredArgsConstructor
+@RequestMapping("/creator/ai")
+@RestController("creatorAiController")
+public class AiController {
+}

--- a/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
+++ b/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
@@ -1,14 +1,20 @@
 package com.github.listen_to_me.controller.creator;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.listen_to_me.common.Result;
+import com.github.listen_to_me.domain.dto.SlotsGenerateDTO;
 import com.github.listen_to_me.domain.vo.AiTaskVO;
+import com.github.listen_to_me.domain.vo.SlotVO;
+import com.github.listen_to_me.service.AiService;
 import com.github.listen_to_me.service.IAiTaskService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @RestController("creatorAiController")
 public class AiController {
 
+    private final AiService aiService;
     private final IAiTaskService aiTaskService;
 
     @PostMapping("/transcript/{audioId}")
@@ -40,5 +47,12 @@ public class AiController {
             @PathVariable String taskId) {
         aiTaskService.confirmTranscript(userId, taskId);
         return Result.success();
+    }
+
+    @PostMapping("/slots")
+    @Operation(summary = "AI 智能排期（预览）")
+    public Result<List<SlotVO>> generateSlots(@AuthenticationPrincipal Long userId,
+            @RequestBody SlotsGenerateDTO dto) {
+        return Result.success(aiService.generateSlots(userId, dto.getDescription()));
     }
 }

--- a/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
+++ b/src/main/java/com/github/listen_to_me/controller/creator/AiController.java
@@ -62,4 +62,12 @@ public class AiController {
             @PathVariable Long audioId) {
         return Result.success(aiTaskService.createSummarizationTask(userId, audioId));
     }
+
+    @PutMapping("/note/{taskId}/confirm")
+    @Operation(summary = "确认摘要结果")
+    public Result<Void> confirmSummary(@AuthenticationPrincipal Long userId,
+            @PathVariable String taskId) {
+        aiTaskService.confirmSummary(userId, taskId);
+        return Result.success();
+    }
 }

--- a/src/main/java/com/github/listen_to_me/domain/dto/SlotsGenerateDTO.java
+++ b/src/main/java/com/github/listen_to_me/domain/dto/SlotsGenerateDTO.java
@@ -1,0 +1,10 @@
+package com.github.listen_to_me.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class SlotsGenerateDTO {
+    @Schema(description = "自然语言描述", example = "每周一三五下午2-4点，单价80元")
+    private String description;
+}

--- a/src/main/java/com/github/listen_to_me/domain/entity/AiTask.java
+++ b/src/main/java/com/github/listen_to_me/domain/entity/AiTask.java
@@ -1,0 +1,25 @@
+package com.github.listen_to_me.domain.entity;
+
+import java.time.LocalDateTime;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import lombok.Data;
+
+@Data
+@TableName("ai_task")
+public class AiTask {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String taskId;
+    private Long userId;
+    private Long audioId;
+    private String type; // TRANSCRIPTION, SUMMARIZATION, SLOT_GENERATION
+    private String status; // PENDING, PROCESSING, SUCCESS, FAILED
+    private String result;
+    private String failReason;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/github/listen_to_me/domain/entity/AudioSummary.java
+++ b/src/main/java/com/github/listen_to_me/domain/entity/AudioSummary.java
@@ -1,0 +1,20 @@
+package com.github.listen_to_me.domain.entity;
+
+import java.time.LocalDateTime;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import lombok.Data;
+
+@Data
+@TableName("audio_summary")
+public class AudioSummary {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private Long audioId;
+    private String taskId;
+    private String summary;
+    private LocalDateTime createTime;
+}

--- a/src/main/java/com/github/listen_to_me/domain/entity/AudioTranscript.java
+++ b/src/main/java/com/github/listen_to_me/domain/entity/AudioTranscript.java
@@ -1,39 +1,20 @@
 package com.github.listen_to_me.domain.entity;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
-import com.baomidou.mybatisplus.annotation.TableName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
-/**
- * <p>
- * 
- * </p>
- *
- * @author baomidou
- * @since 2026-03-25
- */
-@Getter
-@Setter
-@TableName("audio_transcript")
-@Schema(name = "AudioTranscript", description = "")
+@Data
 public class AudioTranscript implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(type = IdType.AUTO)
     private Long id;
-
     private Long audioId;
-
-    @Schema(description = "AI转写文本")
+    private String taskId;
     private String fullText;
-
-    @Schema(description = "AI分段标题与时间戳 [{time: 0, title: }]")
     private String segmentJson;
+    private LocalDateTime createTime;
 }

--- a/src/main/java/com/github/listen_to_me/domain/vo/AiTaskVO.java
+++ b/src/main/java/com/github/listen_to_me/domain/vo/AiTaskVO.java
@@ -1,0 +1,12 @@
+package com.github.listen_to_me.domain.vo;
+
+import lombok.Data;
+
+@Data
+public class AiTaskVO {
+    private String taskId;
+    private String type; // TRANSCRIPTION, SUMMARIZATION, SLOT_GENERATION
+    private String status; // PENDING, PROCESSING, SUCCESS, FAILED
+    private Object result; // 应该转成 JSON 对象
+    private String failReason;
+}

--- a/src/main/java/com/github/listen_to_me/mapper/AiTaskMapper.java
+++ b/src/main/java/com/github/listen_to_me/mapper/AiTaskMapper.java
@@ -1,0 +1,10 @@
+package com.github.listen_to_me.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.github.listen_to_me.domain.entity.AiTask;
+
+@Mapper
+public interface AiTaskMapper extends BaseMapper<AiTask> {
+}

--- a/src/main/java/com/github/listen_to_me/mapper/AudioSummaryMapper.java
+++ b/src/main/java/com/github/listen_to_me/mapper/AudioSummaryMapper.java
@@ -1,0 +1,10 @@
+package com.github.listen_to_me.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.github.listen_to_me.domain.entity.AudioSummary;
+
+@Mapper
+public interface AudioSummaryMapper extends BaseMapper<AudioSummary> {
+}

--- a/src/main/java/com/github/listen_to_me/service/AiService.java
+++ b/src/main/java/com/github/listen_to_me/service/AiService.java
@@ -2,6 +2,8 @@ package com.github.listen_to_me.service;
 
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -9,18 +11,22 @@ import org.springframework.stereotype.Service;
 import com.alibaba.dashscope.aigc.generation.Generation;
 import com.alibaba.dashscope.aigc.generation.GenerationParam;
 import com.alibaba.dashscope.aigc.generation.GenerationResult;
+import com.alibaba.dashscope.aigc.multimodalconversation.MultiModalConversation;
+import com.alibaba.dashscope.aigc.multimodalconversation.MultiModalConversationParam;
+import com.alibaba.dashscope.aigc.multimodalconversation.MultiModalConversationResult;
 import com.alibaba.dashscope.audio.qwen_asr.QwenTranscription;
 import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionParam;
 import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionQueryParam;
 import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionResult;
 import com.alibaba.dashscope.common.Message;
+import com.alibaba.dashscope.common.MultiModalMessage;
 import com.alibaba.dashscope.common.ResponseFormat;
 import com.alibaba.dashscope.common.Role;
 import com.alibaba.dashscope.utils.Constants;
 import com.github.listen_to_me.common.config.DashScopeConfig;
 import com.github.listen_to_me.common.exception.BaseException;
-import com.github.listen_to_me.domain.vo.SlotVO;
 import com.github.listen_to_me.domain.entity.AiTask;
+import com.github.listen_to_me.domain.vo.SlotVO;
 
 import cn.hutool.core.util.IdUtil;
 import cn.hutool.http.HttpRequest;
@@ -160,6 +166,81 @@ public class AiService {
         } catch (Exception e) {
             log.error("DashScope 调用失败 - model: {}", model, e);
             throw new BaseException(500, "AI 调用失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 生成英文摘要
+     *
+     * @param fileUrl 公网可访问的音频文件 URL
+     * @return 英文摘要文本
+     */
+    public String generateSummary(String fileUrl) {
+        log.debug("开始生成英文摘要 - fileUrl: {}", fileUrl);
+
+        MultiModalMessage userMessage = MultiModalMessage.builder()
+                .role(Role.USER.getValue())
+                .content(Collections.singletonList(
+                        new HashMap<String, Object>() {
+                            {
+                                put("audio", fileUrl);
+                            }
+                        }))
+                .build();
+
+        MultiModalConversationParam param = MultiModalConversationParam.builder()
+                .apiKey(dashScopeConfig.getApiKey())
+                .model(dashScopeConfig.getSummarizationModel())
+                .message(userMessage)
+                .build();
+
+        try {
+            MultiModalConversation conv = new MultiModalConversation();
+            MultiModalConversationResult result = conv.call(param);
+            String summary = result.getOutput()
+                    .getChoices().get(0)
+                    .getMessage().getContent().get(0)
+                    .get("text").toString();
+            log.debug("英文摘要生成成功");
+            return summary;
+        } catch (Exception e) {
+            log.error("英文摘要生成失败", e);
+            throw new RuntimeException("英文摘要生成失败: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 翻译摘要为中文
+     *
+     * @param englishSummary 英文摘要
+     * @return 中文摘要
+     */
+    public String translateSummary(String englishSummary) {
+        log.debug("开始翻译摘要");
+
+        String prompt = "请将以下英文内容进行不多于 100 字的中文摘要分析。直接输出结果, 结果不用携带字数说明：\n" + englishSummary;
+
+        Message userMsg = Message.builder()
+                .role(Role.USER.getValue())
+                .content(prompt)
+                .build();
+
+        GenerationParam param = GenerationParam.builder()
+                .apiKey(dashScopeConfig.getApiKey())
+                .model(dashScopeConfig.getTranslationModel())
+                .messages(Arrays.asList(userMsg))
+                .resultFormat(GenerationParam.ResultFormat.MESSAGE)
+                .build();
+
+        try {
+            Generation gen = new Generation();
+            GenerationResult result = gen.call(param);
+            String response = result.getOutput().getChoices().get(0).getMessage().getContent();
+            log.debug("翻译完成");
+            return response;
+        } catch (Exception e) {
+            log.error("翻译失败", e);
+            throw new RuntimeException("翻译失败: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/github/listen_to_me/service/AiService.java
+++ b/src/main/java/com/github/listen_to_me/service/AiService.java
@@ -2,6 +2,14 @@ package com.github.listen_to_me.service;
 
 import org.springframework.stereotype.Service;
 
+import com.alibaba.dashscope.audio.qwen_asr.QwenTranscription;
+import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionParam;
+import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionQueryParam;
+import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionResult;
+import com.alibaba.dashscope.utils.Constants;
+import com.github.listen_to_me.common.config.DashScopeConfig;
+
+import cn.hutool.http.HttpRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -9,4 +17,46 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class AiService {
+
+    private final DashScopeConfig dashScopeConfig;
+
+    /**
+     * 音频转写（录音文件识别）
+     *
+     * @param fileUrl 公网可访问的音频文件 URL
+     * @return 转写结果 JSON 字符串
+     */
+    public String transcribe(String fileUrl) {
+        log.debug("开始音频转写 - fileUrl: {}", fileUrl);
+
+        Constants.baseHttpApiUrl = "https://dashscope.aliyuncs.com/api/v1";
+
+        QwenTranscriptionParam param = QwenTranscriptionParam.builder()
+                .apiKey(dashScopeConfig.getApiKey())
+                .model(dashScopeConfig.getTranscriptionModel())
+                .fileUrl(fileUrl)
+                .parameter("enable_itn", false)
+                .parameter("enable_words", true)
+                .build();
+
+        try {
+            QwenTranscription transcription = new QwenTranscription();
+
+            QwenTranscriptionResult result = transcription.asyncCall(param);
+            String taskId = result.getTaskId();
+            log.debug("转写任务已提交 - taskId: {}", taskId);
+
+            result = transcription.wait(QwenTranscriptionQueryParam.FromTranscriptionParam(param, taskId));
+
+            String transcriptionUrl = result.getResult().getTranscriptionUrl();
+            String content = HttpRequest.get(transcriptionUrl).execute().body();
+
+            log.debug("音频转写成功");
+            return content;
+
+        } catch (Exception e) {
+            log.error("音频转写失败", e);
+            throw new RuntimeException("音频转写失败: " + e.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/com/github/listen_to_me/service/AiService.java
+++ b/src/main/java/com/github/listen_to_me/service/AiService.java
@@ -1,15 +1,30 @@
 package com.github.listen_to_me.service;
 
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.alibaba.dashscope.aigc.generation.Generation;
+import com.alibaba.dashscope.aigc.generation.GenerationParam;
+import com.alibaba.dashscope.aigc.generation.GenerationResult;
 import com.alibaba.dashscope.audio.qwen_asr.QwenTranscription;
 import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionParam;
 import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionQueryParam;
 import com.alibaba.dashscope.audio.qwen_asr.QwenTranscriptionResult;
+import com.alibaba.dashscope.common.Message;
+import com.alibaba.dashscope.common.ResponseFormat;
+import com.alibaba.dashscope.common.Role;
 import com.alibaba.dashscope.utils.Constants;
 import com.github.listen_to_me.common.config.DashScopeConfig;
+import com.github.listen_to_me.common.exception.BaseException;
+import com.github.listen_to_me.domain.vo.SlotVO;
+import com.github.listen_to_me.domain.entity.AiTask;
 
+import cn.hutool.core.util.IdUtil;
 import cn.hutool.http.HttpRequest;
+import cn.hutool.json.JSONUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AiService {
 
     private final DashScopeConfig dashScopeConfig;
+    private final IAiTaskService aiTaskService;
 
     /**
      * 音频转写（录音文件识别）
@@ -57,6 +73,93 @@ public class AiService {
         } catch (Exception e) {
             log.error("音频转写失败", e);
             throw new RuntimeException("音频转写失败: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * AI 生成时间槽（预览）
+     *
+     * @param userId      当前用户ID
+     * @param description 自然语言描述
+     * @return 时间槽列表
+     */
+    public List<SlotVO> generateSlots(Long userId, String description) {
+        log.debug("AI 智能排期 - 用户ID: {}, 描述: {}", userId, description);
+
+        // 创建 AiTask 记录
+        String taskId = IdUtil.fastSimpleUUID();
+        AiTask task = new AiTask();
+        task.setTaskId(taskId);
+        task.setUserId(userId);
+        task.setType("SLOT_GENERATION");
+        task.setStatus("PROCESSING");
+        aiTaskService.save(task);
+
+        try {
+            String prompt = buildSlotPrompt(description);
+            String response = callDashScope(prompt, dashScopeConfig.getSlotModel());
+            List<SlotVO> slots = JSONUtil.toList(JSONUtil.parseArray(response), SlotVO.class);
+
+            // 2. 更新任务状态为 SUCCESS，存储结果
+            task.setStatus("SUCCESS");
+            task.setResult(response);
+            aiTaskService.updateById(task);
+
+            return slots;
+        } catch (Exception e) {
+            task.setStatus("FAILED");
+            task.setFailReason(e.getMessage());
+            aiTaskService.updateById(task);
+            throw e;
+        }
+    }
+
+    /**
+     * 构建排期提示词
+     */
+    private String buildSlotPrompt(String description) {
+        return "你是一个智能排期助手。请根据用户的自然语言描述，生成符合要求的时间槽列表，并以纯 JSON 数组格式返回，不要包含任何其他文本或注释。\n" +
+                "当前日期是：" + LocalDate.now() + "\n" +
+                "用户输入：" + description + "\n" +
+                "生成的 JSON 数组中的每个对象必须包含以下字段：\n" +
+                "- startTime: 开始时间，格式为 'yyyy-MM-dd HH:mm:ss'\n" +
+                "- endTime: 结束时间，格式为 'yyyy-MM-dd HH:mm:ss'\n" +
+                "- price: 预约价格（虚拟币），必须大于0\n" +
+                "- address: 预约地址，若用户未提供则留空字符串 \"\"\n" +
+                "请确保 startTime 早于 endTime，且时间基于当前日期推算。输出示例：\n" +
+                "[{\"startTime\":\"2026-04-21 14:00:00\",\"endTime\":\"2026-04-21 16:00:00\",\"price\":80,\"address\":\"\"}]";
+    }
+
+    /**
+     * 通用 DashScope AI 调用（纯文本）
+     *
+     * @param prompt 提示词
+     * @param model  模型名称
+     * @return AI 返回的文本
+     */
+    private String callDashScope(String prompt, String model) {
+        Message userMsg = Message.builder()
+                .role(Role.USER.getValue())
+                .content(prompt)
+                .build();
+
+        ResponseFormat jsonMode = ResponseFormat.builder().type("json_object").build();
+
+        GenerationParam param = GenerationParam.builder()
+                .apiKey(dashScopeConfig.getApiKey())
+                .model(model)
+                .messages(Arrays.asList(userMsg))
+                .resultFormat(GenerationParam.ResultFormat.MESSAGE)
+                .responseFormat(jsonMode)
+                .build();
+
+        try {
+            Generation gen = new Generation();
+            GenerationResult result = gen.call(param);
+            return result.getOutput().getChoices().get(0).getMessage().getContent();
+        } catch (Exception e) {
+            log.error("DashScope 调用失败 - model: {}", model, e);
+            throw new BaseException(500, "AI 调用失败: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/github/listen_to_me/service/AiService.java
+++ b/src/main/java/com/github/listen_to_me/service/AiService.java
@@ -1,0 +1,12 @@
+package com.github.listen_to_me.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiService {
+}

--- a/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
+++ b/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
@@ -2,6 +2,25 @@ package com.github.listen_to_me.service;
 
 import com.baomidou.mybatisplus.extension.service.IService;
 import com.github.listen_to_me.domain.entity.AiTask;
+import com.github.listen_to_me.domain.vo.AiTaskVO;
 
 public interface IAiTaskService extends IService<AiTask> {
+
+    /**
+     * 根据 taskId 查询任务详情
+     *
+     * @param userId 当前用户ID
+     * @param taskId 任务ID
+     * @return 任务VO
+     */
+    AiTaskVO getTaskById(Long userId, String taskId);
+
+    /**
+     * 创建音频转写任务
+     * 
+     * @param userId  用户ID
+     * @param audioId 音频ID
+     * @return 任务信息
+     */
+    AiTaskVO createTranscriptionTask(Long userId, Long audioId);
 }

--- a/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
+++ b/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
@@ -23,4 +23,12 @@ public interface IAiTaskService extends IService<AiTask> {
      * @return 任务信息
      */
     AiTaskVO createTranscriptionTask(Long userId, Long audioId);
+
+    /**
+     * 确认转写结果，将结果存入 audio_transcript 表
+     *
+     * @param userId 当前用户ID
+     * @param taskId 任务ID
+     */
+    void confirmTranscript(Long userId, String taskId);
 }

--- a/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
+++ b/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
@@ -31,4 +31,13 @@ public interface IAiTaskService extends IService<AiTask> {
      * @param taskId 任务ID
      */
     void confirmTranscript(Long userId, String taskId);
+
+    /**
+     * 创建音频摘要任务
+     *
+     * @param userId  用户ID
+     * @param audioId 音频ID
+     * @return 任务信息
+     */
+    AiTaskVO createSummarizationTask(Long userId, Long audioId);
 }

--- a/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
+++ b/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
@@ -40,4 +40,12 @@ public interface IAiTaskService extends IService<AiTask> {
      * @return 任务信息
      */
     AiTaskVO createSummarizationTask(Long userId, Long audioId);
+
+    /**
+     * 确认摘要结果，将结果存入 audio_summary 表
+     *
+     * @param userId 当前用户ID
+     * @param taskId 任务ID
+     */
+    void confirmSummary(Long userId, String taskId);
 }

--- a/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
+++ b/src/main/java/com/github/listen_to_me/service/IAiTaskService.java
@@ -1,0 +1,7 @@
+package com.github.listen_to_me.service;
+
+import com.baomidou.mybatisplus.extension.service.IService;
+import com.github.listen_to_me.domain.entity.AiTask;
+
+public interface IAiTaskService extends IService<AiTask> {
+}

--- a/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
+++ b/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
@@ -2,11 +2,15 @@ package com.github.listen_to_me.service.impl;
 
 import org.springframework.stereotype.Service;
 
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.github.listen_to_me.common.exception.BaseException;
 import com.github.listen_to_me.domain.entity.AiTask;
+import com.github.listen_to_me.domain.vo.AiTaskVO;
 import com.github.listen_to_me.mapper.AiTaskMapper;
 import com.github.listen_to_me.service.IAiTaskService;
 
+import cn.hutool.json.JSONUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,4 +18,29 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> implements IAiTaskService {
+
+    @Override
+    public AiTaskVO getTaskById(Long userId, String taskId) {
+        AiTask task = getOne(Wrappers.<AiTask>lambdaQuery().eq(AiTask::getTaskId, taskId));
+        if (task == null) {
+            throw new BaseException(404, "任务不存在");
+        }
+
+        if (!task.getUserId().equals(userId)) {
+            throw new BaseException(403, "无权访问该任务");
+        }
+
+        AiTaskVO vo = new AiTaskVO();
+        vo.setTaskId(task.getTaskId());
+        vo.setType(task.getType());
+        vo.setStatus(task.getStatus());
+
+        if (task.getResult() != null) {
+            vo.setResult(JSONUtil.parse(task.getResult()));
+        }
+
+        vo.setFailReason(task.getFailReason());
+        return vo;
+    }
+
 }

--- a/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
+++ b/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
@@ -5,11 +5,15 @@ import org.springframework.stereotype.Service;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.github.listen_to_me.common.exception.BaseException;
+import com.github.listen_to_me.common.producer.AiTaskProducer;
 import com.github.listen_to_me.domain.entity.AiTask;
+import com.github.listen_to_me.domain.entity.AudioInfo;
 import com.github.listen_to_me.domain.vo.AiTaskVO;
 import com.github.listen_to_me.mapper.AiTaskMapper;
 import com.github.listen_to_me.service.IAiTaskService;
+import com.github.listen_to_me.service.IAudioInfoService;
 
+import cn.hutool.core.util.IdUtil;
 import cn.hutool.json.JSONUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +22,9 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> implements IAiTaskService {
+
+    private final AiTaskProducer aiTaskProducer;
+    private final IAudioInfoService audioInfoService;
 
     @Override
     public AiTaskVO getTaskById(Long userId, String taskId) {
@@ -43,4 +50,30 @@ public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> impleme
         return vo;
     }
 
+    @Override
+    public AiTaskVO createTranscriptionTask(Long userId, Long audioId) {
+        log.debug("创建音频转写任务 - 用户ID: {}, 音频ID: {}", userId, audioId);
+
+        // 校验音频是否存在且属于当前用户
+        AudioInfo audio = audioInfoService.getById(audioId);
+        if (audio == null || !audio.getCreatorId().equals(userId)) {
+            throw new BaseException(404, "音频不存在");
+        }
+
+        // 生成任务ID
+        String taskId = IdUtil.fastSimpleUUID();
+
+        // 创建任务记录
+        AiTask task = new AiTask();
+        task.setTaskId(taskId);
+        task.setUserId(userId);
+        task.setAudioId(audioId);
+        task.setType("TRANSCRIPTION");
+        task.setStatus("PENDING");
+
+        aiTaskProducer.sendTranscriptionTask(taskId, audioId);
+
+        save(task);
+        return getTaskById(userId, taskId);
+    }
 }

--- a/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
+++ b/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
@@ -124,4 +124,28 @@ public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> impleme
 
         log.debug("确认转写结果成功 - taskId: {}, audioId: {}", taskId, task.getAudioId());
     }
+
+    @Override
+    public AiTaskVO createSummarizationTask(Long userId, Long audioId) {
+        log.debug("创建音频摘要任务 - 用户ID: {}, 音频ID: {}", userId, audioId);
+
+        AudioInfo audio = audioInfoService.getById(audioId);
+        if (audio == null || !audio.getCreatorId().equals(userId)) {
+            throw new BaseException(404, "音频不存在");
+        }
+
+        String taskId = IdUtil.fastSimpleUUID();
+
+        AiTask task = new AiTask();
+        task.setTaskId(taskId);
+        task.setUserId(userId);
+        task.setAudioId(audioId);
+        task.setType("SUMMARIZATION");
+        task.setStatus("PENDING");
+
+        aiTaskProducer.sendSummarizationTask(taskId, audioId);
+        save(task);
+
+        return getTaskById(userId, taskId);
+    }
 }

--- a/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
+++ b/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
@@ -1,6 +1,7 @@
 package com.github.listen_to_me.service.impl;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
@@ -8,12 +9,16 @@ import com.github.listen_to_me.common.exception.BaseException;
 import com.github.listen_to_me.common.producer.AiTaskProducer;
 import com.github.listen_to_me.domain.entity.AiTask;
 import com.github.listen_to_me.domain.entity.AudioInfo;
+import com.github.listen_to_me.domain.entity.AudioTranscript;
 import com.github.listen_to_me.domain.vo.AiTaskVO;
 import com.github.listen_to_me.mapper.AiTaskMapper;
+import com.github.listen_to_me.mapper.AudioTranscriptMapper;
 import com.github.listen_to_me.service.IAiTaskService;
 import com.github.listen_to_me.service.IAudioInfoService;
 
 import cn.hutool.core.util.IdUtil;
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
 import cn.hutool.json.JSONUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +30,7 @@ public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> impleme
 
     private final AiTaskProducer aiTaskProducer;
     private final IAudioInfoService audioInfoService;
+    private final AudioTranscriptMapper audioTranscriptMapper;
 
     @Override
     public AiTaskVO getTaskById(Long userId, String taskId) {
@@ -75,5 +81,47 @@ public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> impleme
 
         save(task);
         return getTaskById(userId, taskId);
+    }
+
+    @Override
+    @Transactional
+    public void confirmTranscript(Long userId, String taskId) {
+        log.debug("确认转写结果 - 用户ID: {}, 任务ID: {}", userId, taskId);
+
+        AiTask task = getOne(Wrappers.<AiTask>lambdaQuery().eq(AiTask::getTaskId, taskId));
+
+        if (task == null) {
+            throw new BaseException(404, "任务不存在");
+        }
+
+        if (!task.getUserId().equals(userId)) {
+            throw new BaseException(403, "无权操作该任务");
+        }
+
+        if (!"SUCCESS".equals(task.getStatus())) {
+            throw new BaseException(400, "任务未完成，无法确认");
+        }
+
+        JSONObject resultJson = JSONUtil.parseObj(task.getResult());
+        JSONArray transcripts = resultJson.getJSONArray("transcripts");
+        if (transcripts == null || transcripts.isEmpty()) {
+            throw new BaseException(400, "转写结果为空");
+        }
+
+        JSONObject firstTranscript = transcripts.getJSONObject(0);
+        String fullText = firstTranscript.getStr("text");
+        JSONArray words = firstTranscript.getJSONArray("sentences").getJSONObject(0).getJSONArray("words");
+
+        audioTranscriptMapper
+                .delete(Wrappers.<AudioTranscript>lambdaQuery().eq(AudioTranscript::getAudioId, task.getAudioId()));
+
+        AudioTranscript transcript = new AudioTranscript();
+        transcript.setAudioId(task.getAudioId());
+        transcript.setTaskId(taskId);
+        transcript.setFullText(fullText);
+        transcript.setSegmentJson(words.toString());
+        audioTranscriptMapper.insert(transcript);
+
+        log.debug("确认转写结果成功 - taskId: {}, audioId: {}", taskId, task.getAudioId());
     }
 }

--- a/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
+++ b/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
@@ -1,0 +1,17 @@
+package com.github.listen_to_me.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.github.listen_to_me.domain.entity.AiTask;
+import com.github.listen_to_me.mapper.AiTaskMapper;
+import com.github.listen_to_me.service.IAiTaskService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> implements IAiTaskService {
+}

--- a/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
+++ b/src/main/java/com/github/listen_to_me/service/impl/AiTaskServiceImpl.java
@@ -9,9 +9,11 @@ import com.github.listen_to_me.common.exception.BaseException;
 import com.github.listen_to_me.common.producer.AiTaskProducer;
 import com.github.listen_to_me.domain.entity.AiTask;
 import com.github.listen_to_me.domain.entity.AudioInfo;
+import com.github.listen_to_me.domain.entity.AudioSummary;
 import com.github.listen_to_me.domain.entity.AudioTranscript;
 import com.github.listen_to_me.domain.vo.AiTaskVO;
 import com.github.listen_to_me.mapper.AiTaskMapper;
+import com.github.listen_to_me.mapper.AudioSummaryMapper;
 import com.github.listen_to_me.mapper.AudioTranscriptMapper;
 import com.github.listen_to_me.service.IAiTaskService;
 import com.github.listen_to_me.service.IAudioInfoService;
@@ -31,6 +33,7 @@ public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> impleme
     private final AiTaskProducer aiTaskProducer;
     private final IAudioInfoService audioInfoService;
     private final AudioTranscriptMapper audioTranscriptMapper;
+    private final AudioSummaryMapper audioSummaryMapper;
 
     @Override
     public AiTaskVO getTaskById(Long userId, String taskId) {
@@ -147,5 +150,39 @@ public class AiTaskServiceImpl extends ServiceImpl<AiTaskMapper, AiTask> impleme
         save(task);
 
         return getTaskById(userId, taskId);
+    }
+
+    @Override
+    @Transactional
+    public void confirmSummary(Long userId, String taskId) {
+        log.debug("确认摘要结果 - 用户ID: {}, 任务ID: {}", userId, taskId);
+
+        AiTask task = getOne(Wrappers.<AiTask>lambdaQuery().eq(AiTask::getTaskId, taskId));
+        if (task == null) {
+            throw new BaseException(404, "任务不存在");
+        }
+        if (!task.getUserId().equals(userId)) {
+            throw new BaseException(403, "无权操作该任务");
+        }
+        if (!"SUCCESS".equals(task.getStatus())) {
+            throw new BaseException(400, "任务未完成，无法确认");
+        }
+
+        // 解析 result JSON
+        JSONObject resultJson = JSONUtil.parseObj(task.getResult());
+        String summary = resultJson.getStr("summary");
+
+        // 删除该音频的旧摘要记录
+        audioSummaryMapper.delete(Wrappers.<AudioSummary>lambdaQuery()
+                .eq(AudioSummary::getAudioId, task.getAudioId()));
+
+        // 存入 audio_summary 表
+        AudioSummary audioSummary = new AudioSummary();
+        audioSummary.setAudioId(task.getAudioId());
+        audioSummary.setTaskId(taskId);
+        audioSummary.setSummary(summary);
+        audioSummaryMapper.insert(audioSummary);
+
+        log.debug("确认摘要结果成功 - taskId: {}, audioId: {}", taskId, task.getAudioId());
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -97,3 +97,11 @@ alipay:
   # 开发需使用 ngrok 进行内网击穿，格式如下：https://{xxxx}.ngrok-free.app/api/user/callback/alipay
   notifyUrl: ${ALIPAY_NOTIFY_URL}
   gatewayUrl: https://openapi-sandbox.dl.alipaydev.com/gateway.do
+
+aliyun:
+  dashscope:
+    api-key: ${LISTEN_TO_ME_DASHSCOPE_API_KEY}
+    transcription-model: qwen3-asr-flash-filetrans
+    summarization-model: qwen3-omni-30b-a3b-captioner
+    translation-model: qwen-plus
+    slot-model: qwen-plus

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -239,4 +239,7 @@ INSERT INTO `creator_profile` (`user_id`, `intro`) VALUES
 (2, '10年后端开发经验，擅长微服务架构设计、分布式系统、高并发处理。曾任职于多家互联网大厂。'),
 (5, '12年产品经验，从0到1主导过多个千万级用户产品，擅长产品规划和用户增长策略。');
 
+INSERT INTO `audio_summary` (`audio_id`, `task_id`, `summary`) VALUES
+(1, 'test_summary_task_001', '这是心理学入门课程的AI生成摘要，介绍了心理学的基本定义和研究对象。');
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -81,12 +81,14 @@ CREATE TABLE IF NOT EXISTS `audio_info` (
 CREATE TABLE IF NOT EXISTS `audio_transcript` (
   `id` bigint PRIMARY KEY AUTO_INCREMENT,
   `audio_id` bigint NOT NULL,
+  `task_id` varchar(64) COMMENT '关联的AI任务ID',
   `full_text` longtext COMMENT 'AI转写文本',
-  `segment_json` json COMMENT 'AI分段标题与时间戳 [{time: 0, title: "..."}]',
-
+  `segment_json` json COMMENT '完整转写结果（sentences + words + emotion）',
+  `create_time` datetime DEFAULT CURRENT_TIMESTAMP,
   UNIQUE INDEX uk_audio_id (audio_id),
+  INDEX idx_task_id (task_id),
   CONSTRAINT fk_transcript_audio FOREIGN KEY (`audio_id`) REFERENCES `audio_info` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='音频转写结果表';
 
 CREATE TABLE IF NOT EXISTS `audio_order` (
   `id` bigint PRIMARY KEY AUTO_INCREMENT,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -261,7 +261,6 @@ CREATE TABLE IF NOT EXISTS comment_likes (
   CONSTRAINT fk_likes_user FOREIGN KEY (user_id) REFERENCES sys_user(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='评论点赞表';
 
-
 -- 创作者申请表
 CREATE TABLE IF NOT EXISTS creator_apply (
   id bigint PRIMARY KEY AUTO_INCREMENT,
@@ -319,3 +318,20 @@ CREATE TABLE IF NOT EXISTS `user_recharge_order` (
 
     CONSTRAINT fk_recharge_user FOREIGN KEY (`user_id`) REFERENCES `sys_user` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='用户虚拟币充值订单表';
+
+CREATE TABLE IF NOT EXISTS `ai_task` (
+  `id` bigint PRIMARY KEY AUTO_INCREMENT,
+  `task_id` varchar(64) UNIQUE NOT NULL COMMENT '任务ID',
+  `user_id` bigint NOT NULL COMMENT '创建者ID',
+  `audio_id` bigint DEFAULT NULL COMMENT '音频ID（转写/摘要时必填）',
+  `type` ENUM('TRANSCRIPTION', 'SUMMARIZATION', 'SLOT_GENERATION') NOT NULL COMMENT '任务类型',
+  `status` ENUM('PENDING', 'PROCESSING', 'SUCCESS', 'FAILED') NOT NULL DEFAULT 'PENDING' COMMENT '任务状态',
+  `result` json COMMENT '任务结果',
+  `fail_reason` varchar(500) COMMENT '失败原因',
+  `create_time` datetime DEFAULT CURRENT_TIMESTAMP,
+  `update_time` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_task_id (task_id),
+  INDEX idx_user_id (user_id),
+  INDEX idx_audio_id (audio_id),
+  INDEX idx_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='AI任务表';

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -337,3 +337,15 @@ CREATE TABLE IF NOT EXISTS `ai_task` (
   INDEX idx_audio_id (audio_id),
   INDEX idx_status (status)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='AI任务表';
+
+-- 音频摘要结果表
+CREATE TABLE IF NOT EXISTS `audio_summary` (
+  `id` bigint PRIMARY KEY AUTO_INCREMENT,
+  `audio_id` bigint NOT NULL COMMENT '音频ID',
+  `task_id` varchar(64) COMMENT '关联的AI任务ID',
+  `summary` text NOT NULL COMMENT 'AI生成的中文摘要',
+  `create_time` datetime DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE INDEX uk_audio_id (audio_id),
+  INDEX idx_task_id (task_id),
+  CONSTRAINT fk_summary_audio FOREIGN KEY (`audio_id`) REFERENCES `audio_info` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='音频摘要结果表';


### PR DESCRIPTION
# Pull Request: AI 功能实现（转写、摘要、排期）

## 变更概述
本次 PR 实现了三大 AI 功能：音频转写、音频摘要、AI 智能排期。

## 主要变更

### 1. 音频转写
- 异步处理，使用 MQ 队列
- 调用阿里云 DashScope `qwen3-asr-flash-filetrans` 模型
- 支持确认后存入 `audio_transcript` 表
- 接口：`POST /creator/ai/transcript/{audioId}`、`PUT /creator/ai/transcript/{taskId}/confirm`

### 2. 音频摘要
- 异步处理，使用 MQ 队列
- 调用 `qwen3-omni-30b-a3b-captioner` 生成英文摘要，自动翻译为中文
- 支持确认后存入 `audio_summary` 表
- 接口：`POST /creator/ai/note/{audioId}`、`PUT /creator/ai/note/{taskId}/confirm`

### 3. AI 智能排期
- 同步处理，直接返回结果
- 调用 `qwen-plus` 模型解析自然语言
- 返回时间槽列表供前端预览
- 接口：`POST /creator/ai/slots`

### 4. 公共接口
- `GET /common/ai/task/{taskId}` 查询 AI 任务状态

### 5. 数据库变更
- `ai_task` 表：存储 AI 任务记录
- `audio_transcript` 表：新增 `task_id`、`create_time` 字段
- `audio_summary` 表：存储摘要结果

## 影响范围
- 新增 3 个 MQ 队列（转写、摘要）
- 新增 2 个消费者（`TranscriptionConsumer`、`SummarizationConsumer`）
- 新增 `DashScopeConfig` 配置类